### PR TITLE
fix(fzf): use fzf-builtin-tmux option and window dimensions from extra options

### DIFF
--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -129,37 +129,18 @@ run_plugin() {
 	handle_input
 	args+=(--bind "$BACK")
 
-	if [[ "$FZF_BUILTIN_TMUX" == "on" ]]; then
-		# Extract dimensions from args
-		dimensions=""
-		# Need to filter out -p flag and dimensions from args
-		declare -a filtered_args=()
-		for ((i=0; i<${#args[@]}; i++)); do
-			arg="${args[i]}"
-			# Skip -p flag but capture dimensions
-			if [[ "$arg" == "-p" && $((i+1)) -lt ${#args[@]} ]]; then
-				dimensions="${args[i+1]}"
-				# Skip both flag and dimensions
-				((i++))
-				continue
-			fi
-			# Also capture dimensions directly if they match the pattern
-			if [[ "$arg" =~ [0-9]+%,[0-9]+% ]]; then
-				dimensions="$arg"
-				continue
-			fi
-			filtered_args+=("$arg")
-		done
-		
-		# If dimensions weren't found, use default
-		if [[ -z "$dimensions" ]]; then
-			dimensions="75%,75%"
-		fi
-		
-		# Use separate --tmux flag with extracted dimensions for FZF
-		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf --tmux="$dimensions" "${fzf_opts[@]}" "${filtered_args[@]}" | tail -n1)
+	# Use the fzf-builtin-tmux option from extra_options
+	fzf_builtin_tmux=${extra_options["fzf-builtin-tmux"]}
+	window_width=${extra_options["window-width"]}
+	window_height=${extra_options["window-height"]}
+	dimensions="${window_width},${window_height}"
+
+	if [[ "$fzf_builtin_tmux" == "on" ]]; then
+		# Use fzf with --tmux flag
+		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf --tmux="$dimensions" "${fzf_opts[@]}" "${args[@]}" | tail -n1)
 	else
-		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf-tmux "${fzf_opts[@]}" "${args[@]}" | tail -n1)
+		# Use fzf-tmux with -p flag
+		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf-tmux -p "$dimensions" "${fzf_opts[@]}" "${args[@]}" | tail -n1)
 	fi
 }
 

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -130,7 +130,7 @@ run_plugin() {
 	args+=(--bind "$BACK")
 
 	if [[ "$FZF_BUILTIN_TMUX" == "on" ]]; then
-		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf "${fzf_opts[@]}" "${args[@]}" | tail -n1)
+		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf --tmux "${fzf_opts[@]}" "${args[@]}" | tail -n1)
 	else
 		RESULT=$(echo -e "${INPUT}" | sed -E 's/✗/ /g' | fzf-tmux "${fzf_opts[@]}" "${args[@]}" | tail -n1)
 	fi

--- a/sessionx.tmux
+++ b/sessionx.tmux
@@ -96,12 +96,6 @@ handle_args() {
 		HEADER="$HEADER  $(get_fzf-marks_keybind)=󰣉"
 	fi
 
-	if [[ "$FZF_BUILTIN_TMUX" == "on" ]]; then
-		fzf_size_arg="--tmux"
-	else
-		fzf_size_arg="-p"
-	fi
-
 	args=(
 		--bind "$TREE_MODE"
 		--bind "$CONFIGURATION_MODE"
@@ -125,7 +119,6 @@ handle_args() {
 		--preview-window="${preview_location},${preview_ratio},,"
 		--layout="$layout_mode"
 		--pointer="$pointer_icon"
-		"${fzf_size_arg}" "$window_width,$window_height"
 		--prompt "$prompt_icon"
 		--print-query
 		--tac
@@ -160,6 +153,9 @@ handle_extra_options() {
 	extra_options["filter-current"]=$(tmux_option_or_fallback "@sessionx-filter-current" "true")
 	extra_options["custom-paths"]=$(tmux_option_or_fallback "@sessionx-custom-paths" "")
 	extra_options["custom-paths-subdirectories"]=$(tmux_option_or_fallback "@sessionx-custom-paths-subdirectories" "false")
+	extra_options["fzf-builtin-tmux"]=$FZF_BUILTIN_TMUX
+	extra_options["window-width"]=$window_width
+	extra_options["window-height"]=$window_height
 	tmux set-option -g @sessionx-_built-extra-options "$(declare -p extra_options)"
 }
 


### PR DESCRIPTION
feat: Improve tmux popup support, remove redundant fzf resize arg

This pull request introduces several improvements related to tmux popup support in `sessionx.tmux` and `sessionx.sh`, primarily addressing the way `fzf` or `fzf-tmux` are invoked for displaying the session selection interface.

**Key Changes:**

*   **Centralized FZF/FZF-tmux Invocation Logic:** The logic for choosing between `fzf` with the `--tmux` flag or `fzf-tmux` with the `-p` flag has been moved entirely into `sessionx.sh`. This removes redundancy from `sessionx.tmux`.

*   **Use `extra_options` for flags:** Instead of accessing the `FZF_BUILTIN_TMUX` variable directly in `sessionx.sh`, its value is stored in the `extra_options` associative array within `sessionx.tmux` and passed to `sessionx.sh`. The same is applicable for `window_width` and `window_height`.

*   **Dynamic Dimensions:** The dimensions are now passed using the `--tmux` flag (with `fzf`) or the `-p` flag (with `fzf-tmux`) ensuring correct positioning and sizing of the fzf popup within the tmux environment based on `window_width` and `window_height`, which respect tmux's pane resizing features.

*   **Removal of Redundant `fzf_size_arg`:**  The `fzf_size_arg` variable and its usage in `sessionx.tmux` were eliminated because the sizing argument is now handled directly within `sessionx.sh`, improving clarity and reducing complexity.

**Benefits:**

*   **More Robust Tmux Popup Handling:** By centrally managing the FZF/FZF-tmux choice, the script becomes more robust across different environments.
*   **Improved Readability and Maintainability:** Code duplication has been minimized, making the script easier to understand and maintain.
*   **Enhanced Flexibility:** Provides a more flexible framework so other options can be defined as tmux variables and accessed in `sessionx.sh`.

**Testing:**

*   Verified that the plugin still successfully displays the session selection interface when `FZF_BUILTIN_TMUX` is set to on/off.
*   Tested that the dimensions of the popup resize as expected when `window_width` and `window_height` are modified.